### PR TITLE
[codex] Harden runtime process launches

### DIFF
--- a/PsiphonUI/PsiphonUI.csproj
+++ b/PsiphonUI/PsiphonUI.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 

--- a/PsiphonUI/Services/RuntimePathSecurity.cs
+++ b/PsiphonUI/Services/RuntimePathSecurity.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace PsiphonUI.Services;
+
+internal static class RuntimePathSecurity
+{
+    private const string AppDirectoryName = "PsiphonUI";
+
+    public static string GetRuntimeDirectory(string componentName, bool preferMachineSecure)
+    {
+        var root = preferMachineSecure && AdminElevation.IsAdministrator()
+            ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
+            : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        var appRoot = Path.Combine(root, AppDirectoryName);
+        var runtimeRoot = Path.Combine(appRoot, "runtime");
+        var path = Path.Combine(runtimeRoot, componentName);
+        Directory.CreateDirectory(path);
+
+        if (preferMachineSecure && AdminElevation.IsAdministrator())
+        {
+            TryRestrictToElevatedWriters(appRoot);
+            TryRestrictToElevatedWriters(runtimeRoot);
+            TryRestrictToElevatedWriters(path);
+        }
+
+        return path;
+    }
+
+    public static string GetRuntimeRoot(bool machineSecure)
+    {
+        var root = machineSecure
+            ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
+            : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        return Path.Combine(root, AppDirectoryName, "runtime");
+    }
+
+    public static string ResolveSystem32Tool(string fileName)
+    {
+        var systemDirectory = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        var path = Path.Combine(systemDirectory, fileName);
+        return File.Exists(path) ? path : fileName;
+    }
+
+    private static void TryRestrictToElevatedWriters(string path)
+    {
+        try
+        {
+            var security = new DirectorySecurity();
+            var inheritance = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
+            const PropagationFlags propagation = PropagationFlags.None;
+
+            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                FileSystemRights.FullControl,
+                inheritance,
+                propagation,
+                AccessControlType.Allow));
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                FileSystemRights.FullControl,
+                inheritance,
+                propagation,
+                AccessControlType.Allow));
+
+            new DirectoryInfo(path).SetAccessControl(security);
+        }
+        catch
+        {
+            // Best effort: process launch still works on systems where ACL edits are blocked.
+        }
+    }
+}

--- a/PsiphonUI/Services/StartupReaper.cs
+++ b/PsiphonUI/Services/StartupReaper.cs
@@ -14,13 +14,10 @@ public sealed class StartupReaper : IStartupReaper
     public void ReapStaleProcesses()
     {
 
-        var tunnelCoreRoot = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Psiphon",
-            "tunnel-core");
-        var xrayRoot = Path.Combine(Path.GetTempPath(), "Psiphon");
+        var localRuntimeRoot = RuntimePathSecurity.GetRuntimeRoot(machineSecure: false);
+        var machineRuntimeRoot = RuntimePathSecurity.GetRuntimeRoot(machineSecure: true);
 
-        var roots = new[] { tunnelCoreRoot, xrayRoot };
+        var roots = new[] { localRuntimeRoot, machineRuntimeRoot };
 
         Process[] processes;
         try
@@ -88,7 +85,8 @@ public sealed class StartupReaper : IStartupReaper
             }
         }
 
-        TryRemoveStaleLocks(tunnelCoreRoot);
+        TryRemoveStaleLocks(localRuntimeRoot);
+        TryRemoveStaleLocks(machineRuntimeRoot);
 
         if (killed > 0)
         {

--- a/PsiphonUI/Services/SystemProxyService.cs
+++ b/PsiphonUI/Services/SystemProxyService.cs
@@ -38,6 +38,7 @@ public sealed class SystemProxyService : ISystemProxyService
                 return;
             }
 
+            var appProxyServer = BuildAppProxyServer(httpProxyPort);
             if (!File.Exists(BackupPath))
             {
                 var backup = new ProxyBackup
@@ -45,12 +46,22 @@ public sealed class SystemProxyService : ISystemProxyService
                     ProxyEnable = key.GetValue("ProxyEnable") as int? ?? 0,
                     ProxyServer = key.GetValue("ProxyServer") as string ?? "",
                     ProxyOverride = key.GetValue("ProxyOverride") as string ?? "",
+                    OwnedProxyServer = appProxyServer,
                 };
                 WriteBackup(backup);
             }
+            else
+            {
+                var backup = ReadBackup();
+                if (backup is not null)
+                {
+                    backup.OwnedProxyServer = appProxyServer;
+                    WriteBackup(backup);
+                }
+            }
 
             key.SetValue("ProxyEnable", 1, RegistryValueKind.DWord);
-            key.SetValue("ProxyServer", $"127.0.0.1:{httpProxyPort}", RegistryValueKind.String);
+            key.SetValue("ProxyServer", appProxyServer, RegistryValueKind.String);
 
             key.SetValue("ProxyOverride", "<local>", RegistryValueKind.String);
 
@@ -71,8 +82,18 @@ public sealed class SystemProxyService : ISystemProxyService
             if (key is null) return;
 
             var backup = ReadBackup();
+            var currentProxyServer = key.GetValue("ProxyServer") as string ?? "";
             if (backup is not null)
             {
+                if (!IsAppOwnedProxy(currentProxyServer, backup))
+                {
+                    _logger.LogWarning(
+                        "Current system proxy no longer points at PsiphonUI ({ProxyServer}); leaving user settings unchanged",
+                        currentProxyServer);
+                    TryDeleteBackup();
+                    return;
+                }
+
                 key.SetValue("ProxyEnable", backup.ProxyEnable, RegistryValueKind.DWord);
                 if (string.IsNullOrEmpty(backup.ProxyServer))
                 {
@@ -94,7 +115,8 @@ public sealed class SystemProxyService : ISystemProxyService
             }
             else
             {
-                key.SetValue("ProxyEnable", 0, RegistryValueKind.DWord);
+                _logger.LogDebug("No PsiphonUI proxy backup exists; leaving current proxy settings unchanged");
+                return;
             }
 
             NotifyWinINet();
@@ -141,6 +163,24 @@ public sealed class SystemProxyService : ISystemProxyService
         [JsonPropertyName("proxyEnable")] public int ProxyEnable { get; set; }
         [JsonPropertyName("proxyServer")] public string ProxyServer { get; set; } = "";
         [JsonPropertyName("proxyOverride")] public string ProxyOverride { get; set; } = "";
+        [JsonPropertyName("ownedProxyServer")] public string OwnedProxyServer { get; set; } = "";
+    }
+
+    private static string BuildAppProxyServer(int httpProxyPort) => $"127.0.0.1:{httpProxyPort}";
+
+    private static bool IsAppOwnedProxy(string proxyServer, ProxyBackup backup)
+    {
+        if (string.IsNullOrWhiteSpace(proxyServer)) return false;
+
+        var value = proxyServer.Trim();
+        if (!string.IsNullOrWhiteSpace(backup.OwnedProxyServer))
+        {
+            return string.Equals(value, backup.OwnedProxyServer.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        return value.StartsWith("127.0.0.1:", StringComparison.OrdinalIgnoreCase)
+               || value.StartsWith("http=127.0.0.1:", StringComparison.OrdinalIgnoreCase)
+               || value.Contains(";http=127.0.0.1:", StringComparison.OrdinalIgnoreCase);
     }
 
     private void WriteBackup(ProxyBackup backup)

--- a/PsiphonUI/Services/TunnelCoreManager.cs
+++ b/PsiphonUI/Services/TunnelCoreManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -89,11 +90,9 @@ public sealed class TunnelCoreManager : ITunnelCoreManager, IDisposable
 
         try
         {
-            _workDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Psiphon",
-                "tunnel-core");
-            Directory.CreateDirectory(_workDir);
+            _workDir = RuntimePathSecurity.GetRuntimeDirectory(
+                "tunnel-core",
+                preferMachineSecure: AdminElevation.IsAdministrator());
 
             var exePath = ResolveTunnelCoreExe();
             var configPath = Path.Combine(_workDir, "config.json");
@@ -203,10 +202,7 @@ public sealed class TunnelCoreManager : ITunnelCoreManager, IDisposable
             _cts?.Cancel();
             _process = null;
 
-            if (_settings.Settings.SetSystemProxy)
-            {
-                _systemProxy.Clear();
-            }
+            _systemProxy.Clear();
 
             ConnectedServerRegion = "";
             BytesSent = 0;
@@ -527,16 +523,29 @@ public sealed class TunnelCoreManager : ITunnelCoreManager, IDisposable
             }
         }
 
-        var randomName = Path.GetRandomFileName().Replace(".", "") + ".exe";
-        var copyTo = Path.Combine(_workDir!, randomName);
-
-        foreach (var stale in Directory.EnumerateFiles(_workDir!, "*.exe"))
-        {
-            try { File.Delete(stale); } catch {  }
-        }
-
-        File.Copy(bundled, copyTo, overwrite: true);
+        var copyTo = Path.Combine(_workDir!, "psiphon-tunnel-core.exe");
+        CopyFileWithHashVerification(bundled, copyTo);
         return copyTo;
+    }
+
+    private static void CopyFileWithHashVerification(string source, string destination)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        File.Copy(source, destination, overwrite: true);
+
+        var sourceHash = ComputeSha256(source);
+        var copiedHash = ComputeSha256(destination);
+        if (!sourceHash.AsSpan().SequenceEqual(copiedHash))
+        {
+            throw new IOException($"Runtime copy verification failed for {Path.GetFileName(destination)}");
+        }
+    }
+
+    private static byte[] ComputeSha256(string path)
+    {
+        using var sha = SHA256.Create();
+        using var stream = File.OpenRead(path);
+        return sha.ComputeHash(stream);
     }
 
     private string? WriteEmbeddedServerList()

--- a/PsiphonUI/Services/XrayTunManager.cs
+++ b/PsiphonUI/Services/XrayTunManager.cs
@@ -176,11 +176,9 @@ public sealed class XrayTunManager : IXrayTunManager
         }
         _excludeAdapterLuid = 0;
 
-        _workDir = Path.Combine(
-            Path.GetTempPath(),
-            "Psiphon",
-            "xray-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(_workDir);
+        _workDir = RuntimePathSecurity.GetRuntimeDirectory(
+            "xray-" + Guid.NewGuid().ToString("N"),
+            preferMachineSecure: true);
 
         var diagDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -216,7 +214,7 @@ public sealed class XrayTunManager : IXrayTunManager
                 SetError($"Bundled xray resource missing: {name}");
                 return;
             }
-            File.Copy(src, Path.Combine(_workDir, name), overwrite: true);
+            CopyFileWithHashVerification(src, Path.Combine(_workDir, name));
         }
 
         var configPath = Path.Combine(_workDir, "config.json");
@@ -231,14 +229,14 @@ public sealed class XrayTunManager : IXrayTunManager
         var psi = new ProcessStartInfo
         {
             FileName = Path.Combine(_workDir, "xray.exe"),
-
-            Arguments = $"-config \"{configPath}\"",
             WorkingDirectory = _workDir,
             UseShellExecute = false,
             CreateNoWindow = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
+        psi.ArgumentList.Add("-config");
+        psi.ArgumentList.Add(configPath);
 
         psi.Environment["XRAY_LOCATION_ASSET"] = _workDir;
         psi.Environment["V2RAY_LOCATION_ASSET"] = _workDir;
@@ -550,6 +548,11 @@ public sealed class XrayTunManager : IXrayTunManager
             SetError($"xray.exe exited unexpectedly (code={code}). "
                    + $"Last output: {DescribeRecentOutput()}. "
                    + $"Full log: {_xrayLogPath}");
+            _ = Task.Run(async () =>
+            {
+                try { await StopAsync(); }
+                catch (Exception ex) { _logger.LogWarning(ex, "Cleanup after unexpected xray exit failed"); }
+            });
         }
     }
 
@@ -720,26 +723,31 @@ public sealed class XrayTunManager : IXrayTunManager
 
     private void RunTool(string fileName, string args, bool acceptFailure, int timeoutMs = 5000)
     {
+        var toolPath = Path.IsPathRooted(fileName)
+            ? fileName
+            : RuntimePathSecurity.ResolveSystem32Tool(fileName);
+
         var psi = new ProcessStartInfo
         {
-            FileName = fileName,
+            FileName = toolPath,
             Arguments = args,
+            WorkingDirectory = Path.GetDirectoryName(toolPath) ?? AppContext.BaseDirectory,
             UseShellExecute = false,
             CreateNoWindow = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
         using var p = Process.Start(psi)
-            ?? throw new InvalidOperationException($"Couldn't launch {fileName}");
+            ?? throw new InvalidOperationException($"Couldn't launch {toolPath}");
         if (!p.WaitForExit(timeoutMs))
         {
-            throw new InvalidOperationException($"{fileName} timed out");
+            throw new InvalidOperationException($"{toolPath} timed out");
         }
         if (p.ExitCode != 0)
         {
             var stderr = p.StandardError.ReadToEnd();
             var stdout = p.StandardOutput.ReadToEnd();
-            var msg = $"{fileName} {args} failed (exit={p.ExitCode}): {stderr}{stdout}";
+            var msg = $"{toolPath} {args} failed (exit={p.ExitCode}): {stderr}{stdout}";
             try { _xrayLogWriter?.WriteLine("[net] " + msg); } catch {  }
             if (!acceptFailure)
             {
@@ -747,6 +755,26 @@ public sealed class XrayTunManager : IXrayTunManager
             }
             _logger.LogDebug("{Tool} returned non-zero (continuing): {Message}", fileName, msg);
         }
+    }
+
+    private static void CopyFileWithHashVerification(string source, string destination)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        File.Copy(source, destination, overwrite: true);
+
+        var sourceHash = ComputeSha256(source);
+        var copiedHash = ComputeSha256(destination);
+        if (!sourceHash.AsSpan().SequenceEqual(copiedHash))
+        {
+            throw new IOException($"Runtime copy verification failed for {Path.GetFileName(destination)}");
+        }
+    }
+
+    private static byte[] ComputeSha256(string path)
+    {
+        using var sha = SHA256.Create();
+        using var stream = File.OpenRead(path);
+        return sha.ComputeHash(stream);
     }
 
     internal static string BuildConfigJson(int psiphonSocksPort, UserSettings settings)

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ cd PsiphonUI\bin\Release\net8.0-windows10.0.19041.0\win-x64
 .\PsiphonUI.exe
 ```
 
-On first run the app creates `%LOCALAPPDATA%\PsiphonUI\` for settings and
-uses `%LOCALAPPDATA%\Psiphon\tunnel-core\` as the data directory for the
-underlying tunnel-core process (same path the official Psiphon Windows
-client uses, so logs and server state are interchangeable).
+On first run the app stores user settings under `%LOCALAPPDATA%\Psiphon\`.
+Runtime copies of tunnel-core/Xray assets are isolated under
+`%LOCALAPPDATA%\PsiphonUI\runtime\` for normal launches, and under
+`%PROGRAMDATA%\PsiphonUI\runtime\` when system-wide tunneling runs elevated.
 
 ---
 


### PR DESCRIPTION
﻿## Summary
- isolate runtime copies under PsiphonUI-specific runtime directories instead of shared `%TEMP%\Psiphon` / `%LOCALAPPDATA%\Psiphon\tunnel-core` locations
- use `%PROGRAMDATA%\PsiphonUI\runtime` with best-effort Administrators/SYSTEM ACLs for elevated system-wide tunneling
- switch tunnel-core runtime copies to a stable filename and verify copied binaries/assets with SHA-256 before launch
- resolve Windows tools such as `route.exe`, `netsh.exe`, and `powershell.exe` from System32 before launching them elevated
- use `ArgumentList` for the Xray `-config` launch and clean up routing state if Xray exits unexpectedly
- make system proxy cleanup ownership-aware so shutdown/stop does not blindly clobber user proxy settings
- document the new runtime locations

## Why
System-wide tunneling elevates the app and launches child processes. Running elevated children from broad user-writable temp/shared folders leaves room for path/race problems and also creates firewall/Defender pain from randomized tunnel-core filenames. This narrows the runtime surface without redesigning the app into a service/installer model.

## Tradeoffs
This is not a complete privileged-helper redesign. The whole UI can still be elevated for system-wide mode, and source binary provenance/signing is still a separate release-hardening problem. This PR focuses on safer runtime paths, tool resolution, copy verification, and cleanup behavior within the current architecture.

## Validation
- `git diff --check master..HEAD`
- `git show --stat --oneline --summary HEAD`

I could not run `dotnet build` locally because this machine has .NET runtimes but no .NET SDK installed. A local SDK install attempt timed out before installing a usable SDK.
