### PR TITLE
[codex] Correct CDN helper documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ build their own Windows UI around `psiphon-tunnel-core.exe`.
 - Pages: Home, Settings, Logs, About, IP Scanner
 - Optional system-wide tunneling via [Xray-core](https://github.com/XTLS/Xray-core)
   + [wintun](https://www.wintun.net/)
-- Optional CDN-fronting helpers (Akamai / Cloudflare / Fastly / Bunny)
+- Optional CDN-fronting helpers for Fastly overrides and Akamai-style custom
+  edge IP / SNI overrides
 - Start with Windows, minimize to tray, allow LAN connections, etc.
 
 ---


### PR DESCRIPTION
﻿## Summary
- correct the feature list so it matches the implemented CDN-fronting helper behavior
- avoid claiming Cloudflare/Bunny support when the current code implements Fastly overrides plus Akamai-style custom edge IP/SNI overrides

## Why
The README currently lists Akamai / Cloudflare / Fastly / Bunny helpers, but the code path in `CdnFrontingBuilder` only implements Fastly provider/address overrides and Akamai-style custom edge overrides. This keeps expectations accurate for users and contributors.

## Validation
- `git diff --check master..HEAD`
- `git show --stat --oneline --summary HEAD`

Documentation-only change; no build required. I still could not run `dotnet build` locally because this machine has .NET runtimes but no .NET SDK installed.
